### PR TITLE
fix: resolve Vercel build issues and optimize imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,6 @@
         "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
         "@tailwindcss/typography": "^0.5.15",
         "@tailwindcss/vite": "^4.1.3",
-        "@types/axios": "^0.14.0",
         "@types/connect-pg-simple": "^7.0.3",
         "@types/express": "4.17.21",
         "@types/express-session": "^1.18.0",
@@ -3783,17 +3782,6 @@
         "react": "^18 || ^19"
       }
     },
-    "node_modules/@types/axios": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.4.tgz",
-      "integrity": "sha512-9JgOaunvQdsQ/qW2OPmE5+hCeUB52lQSolecrFrthct55QekhmXEwT203s20RL+UHtCQc15y3VXpby9E7Kkh/g==",
-      "deprecated": "This is a stub types definition. axios provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "axios": "*"
-      }
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4495,9 +4483,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001677",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
-      "integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
+      "version": "1.0.30001737",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
+      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.3",
-    "@types/axios": "^0.14.0",
     "@types/connect-pg-simple": "^7.0.3",
     "@types/express": "4.17.21",
     "@types/express-session": "^1.18.0",

--- a/src/components/employees/EmployeeForm.tsx
+++ b/src/components/employees/EmployeeForm.tsx
@@ -1,6 +1,6 @@
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { insertEmployeeSchema, InsertEmployee } from '@shared/schema';
+import { insertEmployeeSchema, InsertEmployee } from '../../../shared/schema';
 import { z } from 'zod';
 
 // Extended schema that includes the code field and handles date strings from API

--- a/src/components/employees/EmployeeTable.tsx
+++ b/src/components/employees/EmployeeTable.tsx
@@ -1,7 +1,7 @@
 import { DataTable, Column, TableAction } from '@/components/common/DataTable';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
-import { Employee } from '@shared/schema';
+import { Employee } from '../../../shared/schema';
 import { Eye, Edit, Trash2 } from 'lucide-react';
 import { format } from 'date-fns';
 import { useState, useEffect } from 'react';

--- a/src/components/leave-form/LeaveForm.tsx
+++ b/src/components/leave-form/LeaveForm.tsx
@@ -16,7 +16,7 @@ import {
   DialogHeader, 
   DialogTitle 
 } from '@/components/ui/dialog';
-import { Leave } from '@shared/schema';
+import { Leave } from '../../../shared/schema';
 import { ColorPicker } from '@/components/common';
 
 // Leave form schema

--- a/src/pages/departments/DepartmentList.tsx
+++ b/src/pages/departments/DepartmentList.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Card, CardContent } from '@/components/ui/card';
 import { departmentService } from '@/services/departmentService';
 import { designationService, Designation as ServiceDesignation } from '@/services/designationService';
-import { Department as SchemaDepartment } from '@shared/schema';
+import { Department as SchemaDepartment } from '../../../shared/schema';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { authToken } from '@/services/authToken';
 import AddDepartmentDialog from '@/components/departments/AddDepartmentDialog';

--- a/src/pages/employees/EmployeeDetail.tsx
+++ b/src/pages/employees/EmployeeDetail.tsx
@@ -1,19 +1,22 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { EmployeeForm } from '@/components/employees/EmployeeForm';
+import { ConfirmationDialog } from '@/components/common';
+import { employeeService } from '@/services/employeeService';
+import { useToast } from '@/hooks/use-toast';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Employee } from '../../../shared/schema';
+import { ArrowLeft, Edit, Download, Calendar, Clock, FileText, DollarSign } from 'lucide-react';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { EmployeeTable } from '@/components/employees/EmployeeTable';
-import { EmployeeForm } from '@/components/employees/EmployeeForm';
 import { EmployeeAttendanceCalendar } from '@/components/employees/EmployeeAttendanceCalendar';
-import { employeeService } from '@/services/employeeService';
 import { attendanceService } from '@/services/attendanceService';
-import { Employee } from '@shared/schema';
-import { ArrowLeft, Edit, Download, Calendar, Clock, FileText, DollarSign } from 'lucide-react';
-import { useToast } from '@/hooks/use-toast';
 import { format } from 'date-fns';
 
 export default function EmployeeDetail() {

--- a/src/pages/employees/EmployeeList.tsx
+++ b/src/pages/employees/EmployeeList.tsx
@@ -7,7 +7,7 @@ import { EmployeeTable } from '@/components/employees/EmployeeTable';
 import { EmployeeForm } from '@/components/employees/EmployeeForm';
 import { ConfirmationDialog } from '@/components/common';
 import { employeeService } from '@/services/employeeService';
-import { Employee, InsertEmployee } from '@shared/schema';
+import { Employee, InsertEmployee } from '../../../shared/schema';
 import { Plus, Filter, Download, Upload } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';

--- a/src/pages/leave-management/LeaveManagementPage.tsx
+++ b/src/pages/leave-management/LeaveManagementPage.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 import { LeaveForm } from '@/components/leave-form';
 import { ConfirmationDialog } from '@/components/common';
-import { Leave } from '@shared/schema';
+import { Leave } from '../../../shared/schema';
 import { leaveService } from '@/services/leaveService';
 import { useToast } from '@/hooks/use-toast';
 import { LoadingSpinner } from '@/components/common';

--- a/src/services/departmentService.ts
+++ b/src/services/departmentService.ts
@@ -1,6 +1,6 @@
-import { httpClient } from '@/services/httpClient';
+import { httpClient } from '@/lib/httpClient';
 import { API_ENDPOINTS } from '@/services/api/endpoints';
-import { Department } from '@shared/schema';
+import { Department } from '../../shared/schema';
 import { FilterRequest, ApiResponse } from '@/types/api';
 
 interface CreateDepartmentRequest {

--- a/src/services/employeeService.ts
+++ b/src/services/employeeService.ts
@@ -1,6 +1,6 @@
 import { httpClient } from '@/lib/httpClient';
 import { API_ENDPOINTS } from '@/services/api/endpoints';
-import { Employee, InsertEmployee } from '@shared/schema';
+import { Employee, InsertEmployee } from '../../shared/schema';
 import { FilterRequest, ApiResponse } from '@/types/api';
 
 class EmployeeService {

--- a/src/services/leaveService.ts
+++ b/src/services/leaveService.ts
@@ -1,6 +1,6 @@
-import { apiClient } from '@/lib/api';
+import { httpClient } from '@/lib/httpClient';
 import { API_ENDPOINTS } from '@/services/api/endpoints';
-import { LeaveRequest, InsertLeaveRequest, Leave, InsertLeave } from '@shared/schema';
+import { LeaveRequest, InsertLeaveRequest, Leave, InsertLeave } from '../../shared/schema';
 import { FilterRequest, ApiResponse } from '@/types/api';
 
 export interface LeaveRequestWithDetails extends LeaveRequest {
@@ -46,53 +46,53 @@ export interface LeaveStatistics {
 class LeaveService {
   // Leave Types
   async getLeaveTypes(filters: FilterRequest = { page: 1, page_size: 100 }): Promise<ApiResponse<Leave[]>> {
-    return apiClient.post<Leave[]>(API_ENDPOINTS.LEAVES_LIST, filters);
+    return httpClient.post<Leave[]>(API_ENDPOINTS.LEAVES_LIST, filters);
   }
 
   async createLeaveType(data: InsertLeave): Promise<ApiResponse<Leave>> {
-    return apiClient.post<Leave>(API_ENDPOINTS.LEAVES_CREATE, data);
+    return httpClient.post<Leave>(API_ENDPOINTS.LEAVES_CREATE, data);
   }
 
   async updateLeaveType(data: Partial<Leave> & { id: string }): Promise<ApiResponse<Leave>> {
-    return apiClient.put<Leave>(API_ENDPOINTS.LEAVES_UPDATE, data);
+    return httpClient.put<Leave>(API_ENDPOINTS.LEAVES_UPDATE, data);
   }
 
   async deleteLeaveType(id: string): Promise<ApiResponse<void>> {
-    return apiClient.patch<void>(API_ENDPOINTS.LEAVES_DELETE, { id });
+    return httpClient.patch<void>(API_ENDPOINTS.LEAVES_DELETE, { id });
   }
 
   // Leave Requests
   async getLeaveRequests(filters: LeaveRequestFilters = { page: 1, page_size: 50 }): Promise<ApiResponse<LeaveRequestWithDetails[]>> {
-    return apiClient.post<LeaveRequestWithDetails[]>(API_ENDPOINTS.LEAVE_REQUESTS_LIST, filters);
+    return httpClient.post<LeaveRequestWithDetails[]>(API_ENDPOINTS.LEAVE_REQUESTS_LIST, filters);
   }
 
   async getLeaveRequest(id: string): Promise<ApiResponse<LeaveRequestWithDetails>> {
-    return apiClient.post<LeaveRequestWithDetails>(API_ENDPOINTS.LEAVE_REQUESTS_ONE, { 
+    return httpClient.post<LeaveRequestWithDetails>(API_ENDPOINTS.LEAVE_REQUESTS_ONE, { 
       id,
       include: ["leave", "employee"]
     });
   }
 
   async createLeaveRequest(data: InsertLeaveRequest): Promise<ApiResponse<LeaveRequest>> {
-    return apiClient.post<LeaveRequest>(API_ENDPOINTS.LEAVE_REQUESTS_CREATE, data);
+    return httpClient.post<LeaveRequest>(API_ENDPOINTS.LEAVE_REQUESTS_CREATE, data);
   }
 
   async updateLeaveRequest(data: Partial<LeaveRequest> & { id: string }): Promise<ApiResponse<LeaveRequest>> {
-    return apiClient.put<LeaveRequest>(API_ENDPOINTS.LEAVE_REQUESTS_UPDATE, data);
+    return httpClient.put<LeaveRequest>(API_ENDPOINTS.LEAVE_REQUESTS_UPDATE, data);
   }
 
   async deleteLeaveRequest(id: string): Promise<ApiResponse<void>> {
-    return apiClient.patch<void>(API_ENDPOINTS.LEAVE_REQUESTS_DELETE, { id });
+    return httpClient.patch<void>(API_ENDPOINTS.LEAVE_REQUESTS_DELETE, { id });
   }
 
   // Leave Statistics
   async getLeaveStatistics(filters: Partial<LeaveRequestFilters> = {}): Promise<ApiResponse<LeaveStatistics>> {
-    return apiClient.post<LeaveStatistics>(API_ENDPOINTS.LEAVE_REQUESTS_STATISTICS, filters);
+    return httpClient.post<LeaveStatistics>(API_ENDPOINTS.LEAVE_REQUESTS_STATISTICS, filters);
   }
 
   // Approve Leave Request
   async approveLeaveRequest(id: string, approverComments?: string): Promise<ApiResponse<LeaveRequest>> {
-    return apiClient.put<LeaveRequest>(API_ENDPOINTS.LEAVE_REQUESTS_UPDATE, {
+    return httpClient.put<LeaveRequest>(API_ENDPOINTS.LEAVE_REQUESTS_UPDATE, {
       id,
       status: 'APPROVED',
       approver_comments: approverComments,
@@ -102,7 +102,7 @@ class LeaveService {
 
   // Reject Leave Request
   async rejectLeaveRequest(id: string, approverComments?: string): Promise<ApiResponse<LeaveRequest>> {
-    return apiClient.put<LeaveRequest>(API_ENDPOINTS.LEAVE_REQUESTS_UPDATE, {
+    return httpClient.put<LeaveRequest>(API_ENDPOINTS.LEAVE_REQUESTS_UPDATE, {
       id,
       status: 'REJECTED',
       approver_comments: approverComments,

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,4 +1,4 @@
-import type { Admin, Employee, Organisation } from '@shared/schema';
+import type { Admin, Employee, Organisation } from '../shared/schema';
 
 export interface AuthTokens {
   access_token: string;

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "framework": "vite",
+  "installCommand": "npm install",
   "rewrites": [
     {
       "source": "/(.*)",
@@ -18,5 +19,8 @@
         }
       ]
     }
-  ]
+  ],
+  "env": {
+    "NODE_ENV": "production"
+  }
 } 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,15 +18,18 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(import.meta.dirname,"src"),
-      "@shared": path.resolve(import.meta.dirname, "shared"),
-      "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+      "@": path.resolve(__dirname, "src"),
+      "@shared": path.resolve(__dirname, "shared"),
+      "@assets": path.resolve(__dirname, "attached_assets"),
     },
   },
-  root: path.resolve(import.meta.dirname),
+  root: path.resolve(__dirname),
   build: {
-    outDir: path.resolve(import.meta.dirname, "dist"),
+    outDir: path.resolve(__dirname, "dist"),
     emptyOutDir: true,
+    rollupOptions: {
+      external: [],
+    },
   },
   server: {
     fs: {


### PR DESCRIPTION
- Fix @shared/schema import path resolution for Vercel builds
- Convert all @shared imports to relative paths for better compatibility
- Update Vite configuration with proper path resolution
- Enhance Vercel configuration for production builds
- Remove deprecated @types/axios dependency
- Update browserslist database
- Ensure all components use proper import paths

Files modified:
- Import paths in 12 component/service files
- vite.config.ts - path resolution fixes
- vercel.json - build optimization
- package.json - dependency cleanup

This resolves the Vercel build failure caused by path alias resolution issues.